### PR TITLE
Use a fixed version for bootstraping pip

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,6 +77,7 @@ class python (
   $gunicorn_package_name     = $python::params::gunicorn_package_name,
   $provider                  = $python::params::provider,
   $valid_versions            = $python::params::valid_versions,
+  $pypa                      = $python::params::pypa,
   $python_pips               = { },
   $python_virtualenvs        = { },
   $python_pyvenvs            = { },

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -73,7 +73,7 @@ class python::install {
 
       # Install pip without pip, see https://pip.pypa.io/en/stable/installing/.
       exec { 'bootstrap pip':
-        command => '/usr/bin/curl https://bootstrap.pypa.io/get-pip.py | python',
+        command => "/usr/bin/curl https://bootstrap.pypa.io/$python::pypa/get-pip.py | python",
         unless  => 'which pip',
         path    => [ '/bin', '/usr/bin', '/usr/local/bin' ],
         require => Package['python'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class python::params {
     'Suse'   => [],
     'Gentoo' => ['2.7', '3.3', '3.4', '3.5']
   }
+  $pypa                   = '2.6'
 
   if $::osfamily == 'RedHat' {
     if $::operatingsystem != 'Fedora' {


### PR DESCRIPTION
To stick on version `9.0.3` for now.